### PR TITLE
[🔀 Shorts-Read] 초기 설정 및 조회 API 구현

### DIFF
--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsEventHandlerService.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsEventHandlerService.java
@@ -1,0 +1,21 @@
+package com.mulmeong.shorts.read.api.application;
+
+import com.mulmeong.shorts.read.api.domain.event.ShortsCreateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsDeleteEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsHashtagUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsInfoUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsStatusUpdateEvent;
+
+public interface ShortsEventHandlerService {
+
+    void createShortsFromEvent(ShortsCreateEvent event);
+
+    void updateShortsHashtagFromEvent(ShortsHashtagUpdateEvent event);
+
+    void updateShortsStatusFromEvent(ShortsStatusUpdateEvent event);
+
+    void updateShortsInfoFromEvent(ShortsInfoUpdateEvent event);
+
+    void deleteShortsFromEvent(ShortsDeleteEvent event);
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsEventHandlerServiceImpl.java
@@ -1,0 +1,56 @@
+package com.mulmeong.shorts.read.api.application;
+
+import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.SHORTS_NOT_FOUND;
+
+import com.mulmeong.shorts.read.api.domain.event.ShortsCreateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsDeleteEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsHashtagUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsInfoUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsStatusUpdateEvent;
+import com.mulmeong.shorts.read.api.infrastructure.ShortsEventRepository;
+import com.mulmeong.shorts.read.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ShortsEventHandlerServiceImpl implements ShortsEventHandlerService {
+
+    private final ShortsEventRepository shortsEventRepository;
+
+    @Override
+    public void createShortsFromEvent(ShortsCreateEvent event) {
+
+        shortsEventRepository.save(event.toDocument());
+    }
+
+    @Override
+    public void updateShortsHashtagFromEvent(ShortsHashtagUpdateEvent event) {
+
+        shortsEventRepository.save(
+            event.toDocument(shortsEventRepository.findByShortsUuid(event.getShortsUuid())
+                .orElseThrow(() -> new BaseException(SHORTS_NOT_FOUND))));
+    }
+
+    @Override
+    public void updateShortsStatusFromEvent(ShortsStatusUpdateEvent event) {
+
+        shortsEventRepository.save(
+            event.toDocument(shortsEventRepository.findByShortsUuid(event.getShortsUuid())
+                .orElseThrow(() -> new BaseException(SHORTS_NOT_FOUND))));
+    }
+
+    @Override
+    public void updateShortsInfoFromEvent(ShortsInfoUpdateEvent event) {
+
+        shortsEventRepository.save(
+            event.toDocument(shortsEventRepository.findByShortsUuid(event.getShortsUuid())
+                .orElseThrow(() -> new BaseException(SHORTS_NOT_FOUND))));
+    }
+
+    @Override
+    public void deleteShortsFromEvent(ShortsDeleteEvent event) {
+
+        shortsEventRepository.deleteByShortsUuid(event.getShortsUuid());
+    }
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryService.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryService.java
@@ -1,9 +1,13 @@
 package com.mulmeong.shorts.read.api.application;
 
+import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+import com.mulmeong.shorts.read.common.utils.CursorPage;
 
 public interface ShortsQueryService {
 
     ShortsResponseDto getSingleShorts(String shortsUuid);
+
+    CursorPage<ShortsResponseDto> getShortsByAuthor(ShortsAuthorRequestDto requestDto);
 
 }

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryService.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryService.java
@@ -1,0 +1,9 @@
+package com.mulmeong.shorts.read.api.application;
+
+import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+
+public interface ShortsQueryService {
+
+    ShortsResponseDto getSingleShorts(String shortsUuid);
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryService.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryService.java
@@ -1,6 +1,7 @@
 package com.mulmeong.shorts.read.api.application;
 
 import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
+import com.mulmeong.shorts.read.api.dto.in.ShortsRecommendationRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
 import com.mulmeong.shorts.read.common.utils.CursorPage;
 
@@ -9,5 +10,7 @@ public interface ShortsQueryService {
     ShortsResponseDto getSingleShorts(String shortsUuid);
 
     CursorPage<ShortsResponseDto> getShortsByAuthor(ShortsAuthorRequestDto requestDto);
+
+    CursorPage<ShortsResponseDto> getRecommendedShorts(ShortsRecommendationRequestDto requestDto);
 
 }

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.mulmeong.shorts.read.api.application;
 import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.SHORTS_NOT_FOUND;
 
 import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
+import com.mulmeong.shorts.read.api.dto.in.ShortsRecommendationRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
 import com.mulmeong.shorts.read.api.infrastructure.ShortsCustomRepository;
 import com.mulmeong.shorts.read.api.infrastructure.ShortsQueryRepository;
@@ -31,6 +32,13 @@ public class ShortsQueryServiceImpl implements ShortsQueryService {
     public CursorPage<ShortsResponseDto> getShortsByAuthor(ShortsAuthorRequestDto requestDto) {
 
         return shortsCustomRepository.getShortsByAuthor(requestDto);
+    }
+
+    @Override
+    public CursorPage<ShortsResponseDto> getRecommendedShorts(
+        ShortsRecommendationRequestDto requestDto) {
+
+        return shortsCustomRepository.getRecommendedShorts(requestDto);
     }
 
 }

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.mulmeong.shorts.read.api.application;
+
+import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.SHORTS_NOT_FOUND;
+
+import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+import com.mulmeong.shorts.read.api.infrastructure.ShortsQueryRepository;
+import com.mulmeong.shorts.read.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ShortsQueryServiceImpl implements ShortsQueryService {
+
+    private final ShortsQueryRepository shortsQueryRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public ShortsResponseDto getSingleShorts(String shortsUuid) {
+
+        return ShortsResponseDto.fromDocument(shortsQueryRepository.findByShortsUuid(shortsUuid)
+            .orElseThrow(() -> new BaseException(SHORTS_NOT_FOUND)));
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/application/ShortsQueryServiceImpl.java
@@ -2,25 +2,35 @@ package com.mulmeong.shorts.read.api.application;
 
 import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.SHORTS_NOT_FOUND;
 
+import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+import com.mulmeong.shorts.read.api.infrastructure.ShortsCustomRepository;
 import com.mulmeong.shorts.read.api.infrastructure.ShortsQueryRepository;
 import com.mulmeong.shorts.read.common.exception.BaseException;
+import com.mulmeong.shorts.read.common.utils.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class ShortsQueryServiceImpl implements ShortsQueryService {
 
     private final ShortsQueryRepository shortsQueryRepository;
+    private final ShortsCustomRepository shortsCustomRepository;
 
-    @Transactional(readOnly = true)
     @Override
     public ShortsResponseDto getSingleShorts(String shortsUuid) {
 
         return ShortsResponseDto.fromDocument(shortsQueryRepository.findByShortsUuid(shortsUuid)
             .orElseThrow(() -> new BaseException(SHORTS_NOT_FOUND)));
+    }
+
+    @Override
+    public CursorPage<ShortsResponseDto> getShortsByAuthor(ShortsAuthorRequestDto requestDto) {
+
+        return shortsCustomRepository.getShortsByAuthor(requestDto);
     }
 
 }

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/document/Shorts.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/document/Shorts.java
@@ -1,0 +1,57 @@
+package com.mulmeong.shorts.read.api.domain.document;
+
+import com.mulmeong.shorts.read.api.domain.model.Hashtag;
+import com.mulmeong.shorts.read.api.domain.model.Media;
+import com.mulmeong.shorts.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor
+@Document(collection = "shorts")
+public class Shorts {
+
+    @Id
+    private String id;
+    private String shortsUuid;
+    private String memberUuid;
+    private String title;
+    private Short playtime;
+    private Visibility visibility;
+    private List<Hashtag> hashtags;
+    private Media media;
+    private Long likeCount;
+    private Long dislikeCount;
+    private Long netLikes;  // likesCount - dislikeCount
+    private Long commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Shorts(String id, String shortsUuid, String memberUuid, String title, Short playtime,
+        Visibility visibility, List<Hashtag> hashtags, Media media, Long likeCount,
+        Long dislikeCount, Long netLikes, Long commentCount, LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+
+        this.id = id;
+        this.shortsUuid = shortsUuid;
+        this.memberUuid = memberUuid;
+        this.title = title;
+        this.playtime = playtime;
+        this.visibility = visibility;
+        this.hashtags = hashtags;
+        this.media = media;
+        this.likeCount = likeCount;
+        this.dislikeCount = dislikeCount;
+        this.netLikes = netLikes;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsCreateEvent.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsCreateEvent.java
@@ -1,0 +1,44 @@
+package com.mulmeong.shorts.read.api.domain.event;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import com.mulmeong.shorts.read.api.domain.model.Hashtag;
+import com.mulmeong.shorts.read.api.domain.model.Media;
+import com.mulmeong.shorts.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ShortsCreateEvent {
+
+    private String shortsUuid;
+    private String memberUuid;
+    private String title;
+    private Short playtime;
+    private Visibility visibility;
+    private List<Hashtag> hashtags;
+    private Media media;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Shorts toDocument() {
+        return Shorts.builder()
+            .shortsUuid(shortsUuid)
+            .memberUuid(memberUuid)
+            .title(title)
+            .playtime(playtime)
+            .visibility(visibility)
+            .hashtags(hashtags)
+            .media(media)
+            .likeCount(0L)
+            .dislikeCount(0L)
+            .netLikes(0L)
+            .commentCount(0L)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsDeleteEvent.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsDeleteEvent.java
@@ -1,0 +1,12 @@
+package com.mulmeong.shorts.read.api.domain.event;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ShortsDeleteEvent {
+
+    private String shortsUuid;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsHashtagUpdateEvent.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsHashtagUpdateEvent.java
@@ -1,0 +1,37 @@
+package com.mulmeong.shorts.read.api.domain.event;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import com.mulmeong.shorts.read.api.domain.model.Hashtag;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ShortsHashtagUpdateEvent {
+
+    private String shortsUuid;
+    private List<Hashtag> hashtags;
+    private LocalDateTime updatedAt;
+
+    public Shorts toDocument(Shorts existingShorts) {
+        return Shorts.builder()
+            .id(existingShorts.getId())
+            .shortsUuid(shortsUuid)
+            .memberUuid(existingShorts.getMemberUuid())
+            .title(existingShorts.getTitle())
+            .playtime(existingShorts.getPlaytime())
+            .visibility(existingShorts.getVisibility())
+            .hashtags(hashtags)
+            .media(existingShorts.getMedia())
+            .likeCount(existingShorts.getLikeCount())
+            .dislikeCount(existingShorts.getDislikeCount())
+            .netLikes(existingShorts.getNetLikes())
+            .commentCount(existingShorts.getCommentCount())
+            .createdAt(existingShorts.getCreatedAt())
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsInfoUpdateEvent.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsInfoUpdateEvent.java
@@ -1,0 +1,36 @@
+package com.mulmeong.shorts.read.api.domain.event;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ShortsInfoUpdateEvent {
+
+    private String shortsUuid;
+    private String title;
+    private Short playtime;
+    private LocalDateTime updatedAt;
+
+    public Shorts toDocument(Shorts existingShorts) {
+        return Shorts.builder()
+            .id(existingShorts.getId())
+            .shortsUuid(shortsUuid)
+            .memberUuid(existingShorts.getMemberUuid())
+            .title(title)
+            .playtime(playtime)
+            .visibility(existingShorts.getVisibility())
+            .hashtags(existingShorts.getHashtags())
+            .media(existingShorts.getMedia())
+            .likeCount(existingShorts.getLikeCount())
+            .dislikeCount(existingShorts.getDislikeCount())
+            .netLikes(existingShorts.getNetLikes())
+            .commentCount(existingShorts.getCommentCount())
+            .createdAt(existingShorts.getCreatedAt())
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsStatusUpdateEvent.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/event/ShortsStatusUpdateEvent.java
@@ -1,0 +1,36 @@
+package com.mulmeong.shorts.read.api.domain.event;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import com.mulmeong.shorts.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ShortsStatusUpdateEvent {
+
+    private String shortsUuid;
+    private Visibility visibility;
+    private LocalDateTime updatedAt;
+
+    public Shorts toDocument(Shorts existingShorts) {
+        return Shorts.builder()
+            .id(existingShorts.getId())
+            .shortsUuid(shortsUuid)
+            .memberUuid(existingShorts.getMemberUuid())
+            .title(existingShorts.getTitle())
+            .playtime(existingShorts.getPlaytime())
+            .visibility(visibility)
+            .hashtags(existingShorts.getHashtags())
+            .media(existingShorts.getMedia())
+            .likeCount(existingShorts.getLikeCount())
+            .dislikeCount(existingShorts.getDislikeCount())
+            .netLikes(existingShorts.getNetLikes())
+            .commentCount(existingShorts.getCommentCount())
+            .createdAt(existingShorts.getCreatedAt())
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/model/Hashtag.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/model/Hashtag.java
@@ -1,0 +1,18 @@
+package com.mulmeong.shorts.read.api.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hashtag {
+
+    private String name;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/model/Media.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/model/Media.java
@@ -1,0 +1,23 @@
+package com.mulmeong.shorts.read.api.domain.model;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class Media {
+
+    private String mediaUuid;
+    private Map<MediaType, MediaInfo> assets;
+
+    @Builder
+    public Media(String mediaUuid, Map<MediaType, MediaInfo> assets) {
+        this.mediaUuid = mediaUuid;
+        this.assets = assets;
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/model/MediaInfo.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/model/MediaInfo.java
@@ -1,0 +1,22 @@
+package com.mulmeong.shorts.read.api.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class MediaInfo {
+
+    private String mediaUrl;
+    private String description;
+
+    @Builder
+    public MediaInfo(String mediaUrl, String description) {
+        this.mediaUrl = mediaUrl;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/model/MediaType.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/model/MediaType.java
@@ -1,0 +1,18 @@
+package com.mulmeong.shorts.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MediaType {
+
+    VIDEO_THUMBNAIL("비디오 썸네일"),
+    STREAMING_360("360p 스트리밍"),
+    STREAMING_540("540p 스트리밍"),
+    STREAMING_720("HD 스트리밍"),
+    VIDEO_MP4("비디오 압축");
+
+    private final String mediaType;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/model/SortType.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/model/SortType.java
@@ -1,0 +1,15 @@
+package com.mulmeong.shorts.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortType {
+
+    LATEST("최신순"),
+    LIKES("좋아요순");
+
+    private final String sortType;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/domain/model/Visibility.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/domain/model/Visibility.java
@@ -1,0 +1,16 @@
+package com.mulmeong.shorts.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Visibility {
+
+    VISIBLE("공개"),
+    HIDDEN("비공개"),
+    REPORTED("신고 처리됨");
+
+    private final String visibility;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/dto/in/ShortsAuthorRequestDto.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/dto/in/ShortsAuthorRequestDto.java
@@ -1,0 +1,35 @@
+package com.mulmeong.shorts.read.api.dto.in;
+
+import com.mulmeong.shorts.read.api.domain.model.SortType;
+import com.mulmeong.shorts.read.api.dto.model.BasePaginationRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ShortsAuthorRequestDto extends BasePaginationRequestDto {
+
+    private String authorUuid;
+    private String requesterUuid;
+
+    public static ShortsAuthorRequestDto toDto(String authorUuid, String requesterUuid,
+        String sortBy, String lastId, Integer pageSize, Integer pageNo) {
+
+        return ShortsAuthorRequestDto.builder()
+            .authorUuid(authorUuid)
+            .requesterUuid(requesterUuid)
+            .sortType(SortType.valueOf(sortBy.toUpperCase()))
+            .lastId(lastId)
+            .pageSize(pageSize)
+            .pageNo(pageNo)
+            .build();
+    }
+
+    @Builder
+    public ShortsAuthorRequestDto(SortType sortType, String lastId, Integer pageSize,
+        Integer pageNo, String authorUuid, String requesterUuid) {
+
+        super(sortType, lastId, pageSize, pageNo);
+        this.authorUuid = authorUuid;
+        this.requesterUuid = requesterUuid;
+    }
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/dto/in/ShortsRecommendationRequestDto.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/dto/in/ShortsRecommendationRequestDto.java
@@ -1,0 +1,35 @@
+package com.mulmeong.shorts.read.api.dto.in;
+
+import com.mulmeong.shorts.read.api.domain.model.SortType;
+import com.mulmeong.shorts.read.api.dto.model.BasePaginationRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ShortsRecommendationRequestDto extends BasePaginationRequestDto {
+
+    private String memberUuid;
+    private boolean isMember;
+
+    public static ShortsRecommendationRequestDto toDto(String memberUuid, boolean isMember,
+        String lastId, Integer pageSize, Integer pageNo) {
+
+        return ShortsRecommendationRequestDto.builder()
+            .memberUuid(memberUuid)
+            .isMember(isMember)
+            .lastId(lastId)
+            .pageSize(pageSize)
+            .pageNo(pageNo)
+            .build();
+    }
+
+    @Builder
+    public ShortsRecommendationRequestDto(SortType sortType, String lastId, Integer pageSize,
+        Integer pageNo, String memberUuid, boolean isMember) {
+
+        super(sortType, lastId, pageSize, pageNo);
+        this.memberUuid = memberUuid;
+        this.isMember = isMember;
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/dto/model/BasePaginationRequestDto.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/dto/model/BasePaginationRequestDto.java
@@ -1,0 +1,16 @@
+package com.mulmeong.shorts.read.api.dto.model;
+
+import com.mulmeong.shorts.read.api.domain.model.SortType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public abstract class BasePaginationRequestDto {
+
+    private SortType sortType;
+    private String lastId;
+    private Integer pageSize;
+    private Integer pageNo;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/dto/out/ShortsResponseDto.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/dto/out/ShortsResponseDto.java
@@ -1,0 +1,64 @@
+package com.mulmeong.shorts.read.api.dto.out;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import com.mulmeong.shorts.read.api.domain.model.Hashtag;
+import com.mulmeong.shorts.read.api.domain.model.Media;
+import com.mulmeong.shorts.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ShortsResponseDto {
+
+    private String shortsUuid;
+    private String memberUuid;
+    private String title;
+    private Short playtime;
+    private Visibility visibility;
+    private List<Hashtag> hashtags;
+    private Media media;
+    private Long likeCount;
+    private Long dislikeCount;
+    private Long commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ShortsResponseDto fromDocument(Shorts shorts) {
+        return ShortsResponseDto.builder()
+            .shortsUuid(shorts.getShortsUuid())
+            .memberUuid(shorts.getMemberUuid())
+            .title(shorts.getTitle())
+            .playtime(shorts.getPlaytime())
+            .visibility(shorts.getVisibility())
+            .hashtags(shorts.getHashtags())
+            .media(shorts.getMedia())
+            .likeCount(shorts.getLikeCount())
+            .dislikeCount(shorts.getDislikeCount())
+            .commentCount(shorts.getCommentCount())
+            .createdAt(shorts.getCreatedAt())
+            .updatedAt(shorts.getUpdatedAt())
+            .build();
+    }
+
+    @Builder
+    public ShortsResponseDto(String shortsUuid, String memberUuid, String title, Short playtime,
+        Visibility visibility, List<Hashtag> hashtags, Media media, Long likeCount,
+        Long dislikeCount, Long commentCount, LocalDateTime createdAt, LocalDateTime updatedAt) {
+
+        this.shortsUuid = shortsUuid;
+        this.memberUuid = memberUuid;
+        this.title = title;
+        this.playtime = playtime;
+        this.visibility = visibility;
+        this.hashtags = hashtags;
+        this.media = media;
+        this.likeCount = likeCount;
+        this.dislikeCount = dislikeCount;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/infrastructure/KafkaConsumer.java
@@ -1,0 +1,66 @@
+package com.mulmeong.shorts.read.api.infrastructure;
+
+import com.mulmeong.shorts.read.api.application.ShortsEventHandlerService;
+import com.mulmeong.shorts.read.api.domain.event.ShortsCreateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsDeleteEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsHashtagUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsInfoUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsStatusUpdateEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaConsumer {
+
+    private final ShortsEventHandlerService shortsEventHandlerService;
+
+    @KafkaListener(topics = "${event.shorts.pub.topics.shorts-create.name}",
+        containerFactory = "shortsCreateEventListener")
+    public void consumeShortsCreateEvent(ShortsCreateEvent event) {
+
+        log.info("Consumed shorts-created event: {}", event);
+        shortsEventHandlerService.createShortsFromEvent(event);
+        log.info("Successfully processed shorts-created event: {}", event);
+    }
+
+    @KafkaListener(topics = "${event.shorts.pub.topics.shorts-delete.name}",
+        containerFactory = "shortsDeleteEventListener")
+    public void consumeShortsDeleteEvent(ShortsDeleteEvent event) {
+
+        log.info("Consumed shorts-deleted event: {}", event);
+        shortsEventHandlerService.deleteShortsFromEvent(event);
+        log.info("Successfully processed shorts-deleted event: {}", event);
+    }
+
+    @KafkaListener(topics = "${event.shorts.pub.topics.shorts-hashtag-update.name}",
+        containerFactory = "shortsHashtagUpdateEventListener")
+    public void consumeShortsHashtagUpdateEvent(ShortsHashtagUpdateEvent event) {
+
+        log.info("Consumed shorts-hashtag-updated event: {}", event);
+        shortsEventHandlerService.updateShortsHashtagFromEvent(event);
+        log.info("Successfully processed shorts-hashtag-updated event: {}", event);
+    }
+
+    @KafkaListener(topics = "${event.shorts.pub.topics.shorts-status-update.name}",
+        containerFactory = "shortsStatusUpdateEventListener")
+    public void consumeShortsStatusUpdateEvent(ShortsStatusUpdateEvent event) {
+
+        log.info("Consumed shorts-status-updated event: {}", event);
+        shortsEventHandlerService.updateShortsStatusFromEvent(event);
+        log.info("Successfully processed shorts-status-updated event: {}", event);
+    }
+
+    @KafkaListener(topics = "${event.shorts.pub.topics.shorts-update.name}",
+        containerFactory = "shortsInfoUpdateEventListener")
+    public void consumeShortsInfoUpdateEvent(ShortsInfoUpdateEvent event) {
+
+        log.info("Consumed shorts-updated event: {}", event);
+        shortsEventHandlerService.updateShortsInfoFromEvent(event);
+        log.info("Successfully processed shorts-updated event: {}", event);
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsCustomRepository.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsCustomRepository.java
@@ -1,19 +1,26 @@
 package com.mulmeong.shorts.read.api.infrastructure;
 
+import static com.mulmeong.shorts.read.api.domain.model.SortType.LIKES;
+
 import com.mulmeong.shorts.read.api.domain.document.QShorts;
 import com.mulmeong.shorts.read.api.domain.document.Shorts;
 import com.mulmeong.shorts.read.api.domain.model.SortType;
 import com.mulmeong.shorts.read.api.domain.model.Visibility;
 import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
+import com.mulmeong.shorts.read.api.dto.in.ShortsRecommendationRequestDto;
 import com.mulmeong.shorts.read.api.dto.model.BasePaginationRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
 import com.mulmeong.shorts.read.common.utils.CursorPage;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
+
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.repository.support.SpringDataMongodbQuery;
 import org.springframework.stereotype.Repository;
 
@@ -38,6 +45,47 @@ public class ShortsCustomRepository {     // QueryDSL Repository
             builder.and(shorts.memberUuid.eq(author)));
 
         return getShortsWithPagination(requestDto, builder);
+    }
+
+    public CursorPage<ShortsResponseDto> getRecommendedShorts(
+        ShortsRecommendationRequestDto requestDto) {
+
+        BooleanBuilder builder = new BooleanBuilder().and(shorts.visibility.eq(Visibility.VISIBLE));
+
+        int curPageNo = Optional.ofNullable(requestDto.getPageNo()).orElse(DEFAULT_PAGE_NUMBER);
+        int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
+        List<Shorts> content = new ArrayList<>();
+
+        if (requestDto.isMember()) {
+            Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(new Criteria("visibility").is(Visibility.VISIBLE)),
+                Aggregation.sample(curPageSize));
+
+            content = mongoTemplate.aggregate(aggregation, "shorts", Shorts.class)
+                .getMappedResults();
+        } else {
+            int offset = Math.max(0, (curPageNo - 1) * curPageSize);
+            SpringDataMongodbQuery<Shorts> query = new SpringDataMongodbQuery<>(mongoTemplate,
+                Shorts.class);
+
+            content = query.where(builder)
+                .orderBy(determineSortOrder(shorts, LIKES))
+                .offset(offset)
+                .limit(curPageSize + 1)
+                .fetch();
+        }
+
+        String nextCursor = null;
+        boolean hasNext = false;
+
+        if (content.size() > curPageSize) {
+            hasNext = true;
+            nextCursor = content.get(curPageSize).getId();
+            content = content.subList(0, curPageSize);
+        }
+
+        return new CursorPage<>(content.stream().map(ShortsResponseDto::fromDocument).toList(),
+            nextCursor, hasNext, content.size(), curPageNo);
     }
 
     private CursorPage<ShortsResponseDto> getShortsWithPagination(

--- a/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsCustomRepository.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsCustomRepository.java
@@ -1,0 +1,82 @@
+package com.mulmeong.shorts.read.api.infrastructure;
+
+import com.mulmeong.shorts.read.api.domain.document.QShorts;
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import com.mulmeong.shorts.read.api.domain.model.SortType;
+import com.mulmeong.shorts.read.api.domain.model.Visibility;
+import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
+import com.mulmeong.shorts.read.api.dto.model.BasePaginationRequestDto;
+import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+import com.mulmeong.shorts.read.common.utils.CursorPage;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.support.SpringDataMongodbQuery;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ShortsCustomRepository {     // QueryDSL Repository
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+
+    private final MongoTemplate mongoTemplate;
+    private final QShorts shorts = QShorts.shorts;
+
+    public CursorPage<ShortsResponseDto> getShortsByAuthor(ShortsAuthorRequestDto requestDto) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (!requestDto.getRequesterUuid().equals(requestDto.getAuthorUuid())) {
+            builder.and(shorts.visibility.eq(Visibility.VISIBLE));
+        }
+        Optional.ofNullable(requestDto.getAuthorUuid()).ifPresent(author ->
+            builder.and(shorts.memberUuid.eq(author)));
+
+        return getShortsWithPagination(requestDto, builder);
+    }
+
+    private CursorPage<ShortsResponseDto> getShortsWithPagination(
+        BasePaginationRequestDto requestDto, BooleanBuilder builder) {
+
+        Optional.ofNullable(requestDto.getLastId()).ifPresent(id -> builder.and(shorts.id.lt(id)));
+
+        int curPageNo = Optional.ofNullable(requestDto.getPageNo()).orElse(DEFAULT_PAGE_NUMBER);
+        int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
+        int offset = Math.max(0, (curPageNo - 1) * curPageSize);
+
+        SpringDataMongodbQuery<Shorts> query = new SpringDataMongodbQuery<>(mongoTemplate,
+            Shorts.class);
+
+        List<Shorts> content = query.where(builder)
+            .orderBy(determineSortOrder(shorts, requestDto.getSortType()))
+            .offset(offset)
+            .limit(curPageSize + 1)
+            .fetch();
+
+        String nextCursor = null;
+        boolean hasNext = false;
+
+        if (content.size() > curPageSize) {
+            hasNext = true;
+            nextCursor = content.get(curPageSize).getId();
+            content = content.subList(0, curPageSize);
+        }
+
+        return new CursorPage<>(content.stream().map(ShortsResponseDto::fromDocument).toList(),
+            nextCursor, hasNext, content.size(), curPageNo);
+    }
+
+    private OrderSpecifier<?> determineSortOrder(QShorts shorts, SortType sortType) {
+
+        return switch (sortType) {
+            case LATEST -> shorts.createdAt.desc();
+            case LIKES -> shorts.netLikes.desc();
+        };
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsEventRepository.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsEventRepository.java
@@ -1,0 +1,13 @@
+package com.mulmeong.shorts.read.api.infrastructure;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ShortsEventRepository extends MongoRepository<Shorts, String> {
+
+    Optional<Shorts> findByShortsUuid(String shortsUuid);
+
+    void deleteByShortsUuid(String shortsUuid);
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsQueryRepository.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/infrastructure/ShortsQueryRepository.java
@@ -1,0 +1,11 @@
+package com.mulmeong.shorts.read.api.infrastructure;
+
+import com.mulmeong.shorts.read.api.domain.document.Shorts;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ShortsQueryRepository extends MongoRepository<Shorts, String> {
+
+    Optional<Shorts> findByShortsUuid(String shortsUuid);
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/presentation/AuthRequiredShortsQueryController.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/presentation/AuthRequiredShortsQueryController.java
@@ -1,0 +1,46 @@
+package com.mulmeong.shorts.read.api.presentation;
+
+import com.mulmeong.shorts.read.api.application.ShortsQueryService;
+import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
+import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+import com.mulmeong.shorts.read.common.response.BaseResponse;
+import com.mulmeong.shorts.read.common.utils.CursorPage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth Required Shorts")
+@RequiredArgsConstructor
+@RequestMapping("/auth/v1/members")
+@RestController
+public class AuthRequiredShortsQueryController {
+
+    private final ShortsQueryService shortsQueryService;
+
+    @Operation(summary = "특정 사용자가 작성한 Shorts 목록 조회",
+        description = """
+            - **요청자와 작성자의 memberUuid가 같으면** 조건에 맞는 모든 Shorts를,
+            같지 않으면 Visibility = `VISIBLE`인 Shorts만을 조회<br><br>
+            - 작성자: **Path Parameter**, 요청자: Member-Uuid in **Header**<br><br>
+            - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
+            - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
+    @GetMapping("/{memberUuid}/shorts")
+    public BaseResponse<CursorPage<ShortsResponseDto>> getShortsByAuthor(
+        @PathVariable(name = "memberUuid") String authorUuid,
+        @RequestHeader("Member-Uuid") String requesterUuid,
+        @RequestParam(defaultValue = "latest", required = false) String sortBy,
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(shortsQueryService.getShortsByAuthor(ShortsAuthorRequestDto.toDto(
+            authorUuid, requesterUuid, sortBy, lastId, pageSize, pageNo)));
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/api/presentation/AuthRequiredShortsQueryController.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/presentation/AuthRequiredShortsQueryController.java
@@ -2,6 +2,7 @@ package com.mulmeong.shorts.read.api.presentation;
 
 import com.mulmeong.shorts.read.api.application.ShortsQueryService;
 import com.mulmeong.shorts.read.api.dto.in.ShortsAuthorRequestDto;
+import com.mulmeong.shorts.read.api.dto.in.ShortsRecommendationRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
 import com.mulmeong.shorts.read.common.response.BaseResponse;
 import com.mulmeong.shorts.read.common.utils.CursorPage;
@@ -17,20 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth Required Shorts")
 @RequiredArgsConstructor
-@RequestMapping("/auth/v1/members")
+@RequestMapping("/auth/v1/members/{memberUuid}/shorts")
 @RestController
 public class AuthRequiredShortsQueryController {
 
     private final ShortsQueryService shortsQueryService;
 
-    @Operation(summary = "특정 사용자가 작성한 Shorts 목록 조회",
+    @Operation(summary = "특정 사용자가 작성한 Shorts 목록 조회 API",
         description = """
             - **요청자와 작성자의 memberUuid가 같으면** 조건에 맞는 모든 Shorts를,
             같지 않으면 Visibility = `VISIBLE`인 Shorts만을 조회<br><br>
             - 작성자: **Path Parameter**, 요청자: Member-Uuid in **Header**<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
-    @GetMapping("/{memberUuid}/shorts")
+    @GetMapping
     public BaseResponse<CursorPage<ShortsResponseDto>> getShortsByAuthor(
         @PathVariable(name = "memberUuid") String authorUuid,
         @RequestHeader("Member-Uuid") String requesterUuid,
@@ -41,6 +42,18 @@ public class AuthRequiredShortsQueryController {
 
         return new BaseResponse<>(shortsQueryService.getShortsByAuthor(ShortsAuthorRequestDto.toDto(
             authorUuid, requesterUuid, sortBy, lastId, pageSize, pageNo)));
+    }
+
+    @Operation(summary = "특정 사용자에게 추천되는 쇼츠 목록 조회 API", description = "(임시) Visibility: `VISIBLE`인 쇼츠 목록만 조회")
+    @GetMapping("/recommendation")
+    public BaseResponse<CursorPage<ShortsResponseDto>> getRecommendedShortsForMember(
+        @PathVariable String memberUuid,
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(shortsQueryService.getRecommendedShorts(
+            ShortsRecommendationRequestDto.toDto(memberUuid, true, lastId, pageSize, pageNo)));
     }
 
 }

--- a/src/main/java/com/mulmeong/shorts/read/api/presentation/ShortsQueryController.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/presentation/ShortsQueryController.java
@@ -1,14 +1,17 @@
 package com.mulmeong.shorts.read.api.presentation;
 
 import com.mulmeong.shorts.read.api.application.ShortsQueryService;
+import com.mulmeong.shorts.read.api.dto.in.ShortsRecommendationRequestDto;
 import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
 import com.mulmeong.shorts.read.common.response.BaseResponse;
+import com.mulmeong.shorts.read.common.utils.CursorPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Shorts Query")
@@ -28,6 +31,20 @@ public class ShortsQueryController {
     public BaseResponse<ShortsResponseDto> getSingleShorts(@PathVariable String shortsUuid) {
 
         return new BaseResponse<>(shortsQueryService.getSingleShorts(shortsUuid));
+    }
+
+    @Operation(summary = "비회원에게 추천되는 Shorts 목록 조회 API", description = """
+        - netLikes 내림차순 조회<br><br>
+        - Visibility: `VISIBLE`인 쇼츠 목록만 조회
+        """)
+    @GetMapping("/recommendation")
+    public BaseResponse<CursorPage<ShortsResponseDto>> getRecommendedShortsForGuest(
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(shortsQueryService.getRecommendedShorts(
+            ShortsRecommendationRequestDto.toDto(null, false, lastId, pageSize, pageNo)));
     }
 
 }

--- a/src/main/java/com/mulmeong/shorts/read/api/presentation/ShortsQueryController.java
+++ b/src/main/java/com/mulmeong/shorts/read/api/presentation/ShortsQueryController.java
@@ -1,0 +1,33 @@
+package com.mulmeong.shorts.read.api.presentation;
+
+import com.mulmeong.shorts.read.api.application.ShortsQueryService;
+import com.mulmeong.shorts.read.api.dto.out.ShortsResponseDto;
+import com.mulmeong.shorts.read.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Shorts Query")
+@RequiredArgsConstructor
+@RequestMapping("/v1/shorts")
+@RestController
+public class ShortsQueryController {
+
+    private final ShortsQueryService shortsQueryService;
+
+    @Operation(summary = "Shorts 단건 정보 조회 API", description = """
+        - Visibility: `VISIBLE` / `HIDDEN` / `REPORTED`<br>
+        - MediaType: `VIDEO_THUMBNAIL` / `VIDEO_360` / `VIDEO_540` / `VIDEO_720` / `VIDEO_MP4`<br><br>
+        - playtime: second 기준으로 입력 ex) 90 sec => 90 저장 **(Range: 0 ~ 32767)**
+        - ShortsMedia 테이블은 **FE에서 생성한 MediaUUID를 기본키로 설정**하는 것에 주의""")
+    @GetMapping("/{shortsUuid}")
+    public BaseResponse<ShortsResponseDto> getSingleShorts(@PathVariable String shortsUuid) {
+
+        return new BaseResponse<>(shortsQueryService.getSingleShorts(shortsUuid));
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/config/KafkaConsumerConfig.java
@@ -43,7 +43,9 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, ShortsHashtagUpdateEvent> shortsHashtagUpdateEventListener() {
+    public ConcurrentKafkaListenerContainerFactory<String, ShortsHashtagUpdateEvent>
+        shortsHashtagUpdateEventListener() {
+
         return kafkaListenerContainerFactory(ShortsHashtagUpdateEvent.class);
     }
 

--- a/src/main/java/com/mulmeong/shorts/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,91 @@
+package com.mulmeong.shorts.read.common.config;
+
+import com.mulmeong.shorts.read.api.domain.event.ShortsCreateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsDeleteEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsHashtagUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsInfoUpdateEvent;
+import com.mulmeong.shorts.read.api.domain.event.ShortsStatusUpdateEvent;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    /**
+     * 특정 이벤트의 메시지를 소비하는 Kafka Listener 컨테이너 팩토리를 생성.
+     *
+     * @return KafkaListenerContainerFactory, KafkaListener가 사용하는 기본 ConsumerFactory
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ShortsCreateEvent> shortsCreateEventListener() {
+        return kafkaListenerContainerFactory(ShortsCreateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ShortsDeleteEvent> shortsDeleteEventListener() {
+        return kafkaListenerContainerFactory(ShortsDeleteEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ShortsHashtagUpdateEvent> shortsHashtagUpdateEventListener() {
+        return kafkaListenerContainerFactory(ShortsHashtagUpdateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ShortsStatusUpdateEvent> shortsStatusUpdateEventListener() {
+        return kafkaListenerContainerFactory(ShortsStatusUpdateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ShortsInfoUpdateEvent> shortsInfoUpdateEventListener() {
+        return kafkaListenerContainerFactory(ShortsInfoUpdateEvent.class);
+    }
+
+    /**
+     * 특정 메시지 타입에 맞게 ConsumerFactory 생성.
+     *
+     * @param messageType 제네릭으로 선언한 Event 객체
+     * @return DefaultKafkaConsumerFactory, Kafka Listener가 사용하는 기본 Consumer Factory
+     */
+    public <T> ConsumerFactory<String, T> consumerFactory(Class<T> messageType) {
+        return new DefaultKafkaConsumerFactory<>(Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+            ConsumerConfig.GROUP_ID_CONFIG, groupId,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
+            JsonDeserializer.VALUE_DEFAULT_TYPE, messageType.getName(),
+            JsonDeserializer.TRUSTED_PACKAGES, "com.mulmeong.shorts.read.api.domain.event"
+        ));
+    }
+
+    /**
+     * 컨테이너 팩토리는 다중 스레드에서 Kafka 메시지를 처리하며, 이 설정을 통해 KafkaListener가 메시지를 소비.
+     *
+     * @param messageType 제네릭으로 선언한 Event 객체
+     * @return ConcurrentKafkaListenerContainerFactory, 다중 스레드에서 Kafka 메시지를 처리하는 컨테이너 팩토리
+     */
+    public <T> ConcurrentKafkaListenerContainerFactory<String, T> kafkaListenerContainerFactory(
+        Class<T> messageType) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory(messageType));
+        factory.getContainerProperties().setGroupId(groupId);
+        return factory;
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.mulmeong.shorts.read.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String BEARER_TOKEN_PREFIX = "Bearer";
+
+    @Bean
+    public OpenAPI openApi() {
+
+        String securityJwtName = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityJwtName);
+        Components components = new Components()
+            .addSecuritySchemes(securityJwtName, new SecurityScheme()
+                .name(securityJwtName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(BEARER_TOKEN_PREFIX)
+                .bearerFormat(securityJwtName));
+
+        return new OpenAPI()
+            .addSecurityItem(securityRequirement)
+            .components(components)
+            .addServersItem(new Server().url("/shorts-read-service"))
+            .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Qua - SHORTS QUERY SERVICE API")
+            .version("v1")
+            .description("Shorts Query Service API Docs");
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/exception/BaseException.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/exception/BaseException.java
@@ -1,0 +1,14 @@
+package com.mulmeong.shorts.read.common.exception;
+
+import com.mulmeong.shorts.read.common.response.BaseResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final BaseResponseStatus status;
+
+    public BaseException(BaseResponseStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.mulmeong.shorts.read.common.exception;
+
+import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.INTERNAL_SERVER_ERROR;
+import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.INVALID_INPUT_VALUE;
+
+import com.mulmeong.shorts.read.common.response.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 전역 예외 처리 및 JSON 형식의 일관된 에러 응답 제공
+
+    /**
+     * BaseException 예외 처리.
+     */
+    @ExceptionHandler(BaseException.class)
+    protected BaseResponse<Void> baseError(BaseException e) {
+        log.error("BaseException -> {} ({})", e.getStatus(), e.getStatus().getMessage(), e);
+
+        return new BaseResponse<>(e.getStatus());
+    }
+
+    /**
+     * Validation 유효성 검사 실패 예외 처리.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected BaseResponse<Void> handleValidException(MethodArgumentNotValidException e) {
+        String message = e.getFieldErrors().get(0).getDefaultMessage();
+        log.error("MethodArgumentNotValidException -> {}", message);
+
+        return new BaseResponse<>(INVALID_INPUT_VALUE, message);
+    }
+
+    /**
+     * 예기치 않은 에러. RuntimeException 예외 처리
+     */
+    @ExceptionHandler(RuntimeException.class)
+    protected BaseResponse<Void> runtimeError(RuntimeException e) {
+        log.error("RuntimeException -> {}", e.getMessage(), e);
+
+        return new BaseResponse<>(INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/health/HealthCheckController.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/health/HealthCheckController.java
@@ -1,0 +1,20 @@
+package com.mulmeong.shorts.read.common.health;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health-check")
+    public ResponseEntity<Void> checkHealthStatus() {
+
+        return new ResponseEntity<>(OK);
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/response/BaseResponse.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/response/BaseResponse.java
@@ -1,0 +1,52 @@
+package com.mulmeong.shorts.read.common.response;
+
+import static com.mulmeong.shorts.read.common.response.BaseResponseStatus.SUCCESS;
+
+import com.mulmeong.shorts.read.common.utils.TypeCaster;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message,
+                              int code, T result) {
+
+    // 필요값 : Http 상태코드, 성공여부, 메시지, 에러코드, 결과값
+
+    /**
+     * 1. Return 객체가 필요한 경우 -> 성공
+     *
+     * @param result 반환해야 하는 결과 객체
+     */
+    public BaseResponse(T result) {
+        this(HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), result);
+    }
+
+    /**
+     * 2. Return 객체가 필요 없는 경우 -> 성공
+     */
+
+    public BaseResponse() {
+        this(HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), null);
+    }
+
+    /**
+     * 3. 요청에 실패한 경우
+     *
+     * @param status 응답 상태
+     */
+    public BaseResponse(BaseResponseStatus status) {
+        this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(),
+            TypeCaster.castMessage(status.getMessage()));
+    }
+
+    /**
+     * 4. 요청에 실패한 경우
+     *
+     * @param status 응답 상태
+     * @param message 에러 메시지
+     */
+    public BaseResponse(BaseResponseStatus status, String message) {
+        this(status.getHttpStatusCode(), false, message, status.getCode(),
+            TypeCaster.castMessage(status.getMessage()));
+    }
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/response/BaseResponseStatus.java
@@ -1,0 +1,39 @@
+package com.mulmeong.shorts.read.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum BaseResponseStatus {
+
+    /**
+     * 200: 요청 성공.
+     **/
+    SUCCESS(HttpStatus.OK, true, 200, "요청에 성공하였습니다."),
+
+    /**
+     * 400: 사용자 요청 에러.
+     */
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, false, 400, "잘못된 요청입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, false, 401, "적절하지 않은 요청값입니다."),
+
+    /**
+     * 900: 기타 에러.
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 900, "서버에서 예기치 않은 오류가 발생했습니다."),
+
+    /**
+     * 2000: Shorts Service 에러.
+     */
+    SHORTS_FORBIDDEN(HttpStatus.FORBIDDEN, false, 1003, "쇼츠 접근 권한이 없습니다."),
+    SHORTS_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 쇼츠 정보입니다.");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/utils/CursorPage.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/utils/CursorPage.java
@@ -1,0 +1,36 @@
+package com.mulmeong.shorts.read.common.utils;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CursorPage<T> {
+
+    private List<T> content;
+    private String nextCursor;
+    private Boolean hasNext;
+    private Integer pageSize;
+    private Integer pageNo;
+
+    public static <T, U> CursorPage<T> toCursorPage(CursorPage<U> cursorPage, List<T> content) {
+
+        return CursorPage.<T>builder()
+            .content(content)
+            .nextCursor(cursorPage.getNextCursor())
+            .hasNext(cursorPage.getHasNext())
+            .pageSize(cursorPage.getPageSize())
+            .pageNo(cursorPage.getPageNo())
+            .build();
+    }
+
+    @Builder
+    public CursorPage(List<T> content, String nextCursor, Boolean hasNext, Integer pageSize,
+        Integer pageNo) {
+        this.content = content;
+        this.nextCursor = nextCursor;
+        this.hasNext = hasNext;
+        this.pageSize = pageSize;
+        this.pageNo = pageNo;
+    }
+}

--- a/src/main/java/com/mulmeong/shorts/read/common/utils/TypeCaster.java
+++ b/src/main/java/com/mulmeong/shorts/read/common/utils/TypeCaster.java
@@ -1,0 +1,14 @@
+package com.mulmeong.shorts.read.common.utils;
+
+public class TypeCaster {
+
+    @SuppressWarnings("unchecked")
+    public static <T> T castMessage(Object message) {
+        try {
+            return (T) message;
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Title: [🔀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.08 ~ 2024.12.08

### 🌵 Branch
feature/shorts-read/#3 → develop

### 📢 Description
- 초기 설정 파일 생성 (Config-server yml, Gateway yml, Swagger Config, Kafka Consumer Config, GlobalExceptionHanlder ... )
- Shorts Service Event Handling
- Shorts 단건 조회 API 구현
- 특정 사용자가 작성한 쇼츠 목록 조회 API 구현
- 특정 사용자 / 비회원에게 추천되는 쇼츠 목록 조회 (임시)

### 💬 Issue Number
- #3 

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
- 임시 배포 후 테스트 완료
- 추천 알고리즘은 Elasticsearch 학습 이후 수정 예정